### PR TITLE
Fixed Typo <ul/>  =>  </ul>

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ request.
           {json.results.map(pokemon =>
             <li>{pokemon.name}</li>
           )}
-        <ul/>
+        </ul>
       )
     }
 


### PR DESCRIPTION
There was a spelling error that was breaking the example.